### PR TITLE
Change arduino-lint from submit to update.

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -23,4 +23,4 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           project-type: library
-          library-manager: submit
+          library-manager: update


### PR DESCRIPTION
This is necessary because the library has been added to the library index manager.